### PR TITLE
Fix indentation issue in post_filter method definition

### DIFF
--- a/ploomes_client/collections/filters.py
+++ b/ploomes_client/collections/filters.py
@@ -195,7 +195,7 @@ class Filters:
             filters={k: v for k, v in filters.items() if v is not None},
         )
 
-     def post_filter(
+    def post_filter(
         self,
         payload,
         filter_=None,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="ploomes-api-client",
-    version="0.2.145",
+    version="0.2.146",
     packages=find_packages(),
     url="https://github.com/victorfigueredo/ploomes-api-client",
     author="Victor Figueredo",


### PR DESCRIPTION
This PR corrects an indentation issue in the post_filter method within the Filters class. The method was incorrectly indented, which could lead to misinterpretation of its scope or raise a syntax error in strict environments.
