### PR TITLE
Fix payload formatting by JSON-dumping before POST and PATCH requests

### DIFF
--- a/ploomes_client/collections/contacts.py
+++ b/ploomes_client/collections/contacts.py
@@ -271,7 +271,7 @@ class Contacts:
             "$top": top,
             "$expand": expand,
         }
-        
+        payload = json.dumps(payload)
         return self.client.request(
             "POST",
             self.path,
@@ -419,6 +419,8 @@ class Contacts:
             "$top": top,
             "$expand": expand,
         }
+
+        payload = json.dumps(payload)
         
         return self.client.request(
             "PATCH",

--- a/ploomes_client/collections/deals.py
+++ b/ploomes_client/collections/deals.py
@@ -225,7 +225,7 @@ class Deals:
             "$top": top,
             "$expand": expand,
         }
-        
+        payload = json.dumps(payload)
         return self.client.request(
             "POST",
             self.path,
@@ -299,7 +299,7 @@ class Deals:
             "$top": top,
             "$expand": expand,
         }
-        
+        payload = json.dumps(payload)
         return self.client.request(
             "PATCH",
             self.path + f"({id_})",

--- a/ploomes_client/collections/fields.py
+++ b/ploomes_client/collections/fields.py
@@ -135,7 +135,7 @@ class Fields:
             "$top": top,
             "$expand": expand,
         }
-        
+        payload = json.dumps(payload)
         return self.client.request(
             "POST",
             self.path,

--- a/ploomes_client/collections/filters.py
+++ b/ploomes_client/collections/filters.py
@@ -231,7 +231,7 @@ class Filters:
             "$top": top,
             "$expand": expand,
         }
-        
+        payload = json.dumps(payload)
         return self.client.request(
             "POST",
             self.path,
@@ -277,7 +277,7 @@ class Filters:
             "$top": top,
             "$expand": expand,
         }
-        
+        payload = json.dumps(payload)
         return self.client.request(
             "PATCH",
             self.path + f"({id_})",

--- a/ploomes_client/collections/interaction_records.py
+++ b/ploomes_client/collections/interaction_records.py
@@ -226,7 +226,7 @@ class InteractionRecords:
             "$top": top,
             "$expand": expand,
         }
-        
+        payload = json.dumps(payload)
         return self.client.request(
             "POST",
             self.path,
@@ -255,6 +255,8 @@ class InteractionRecords:
             "$top": top,
             "$expand": expand,
         }
+        
+        payload = json.dumps(payload)
         
         return self.client.request(
             "POST",
@@ -301,6 +303,8 @@ class InteractionRecords:
             "$top": top,
             "$expand": expand,
         }
+        
+        payload = json.dumps(payload)
         
         return self.client.request(
             "PATCH",

--- a/ploomes_client/collections/products.py
+++ b/ploomes_client/collections/products.py
@@ -132,3 +132,130 @@ class Products:
             dict: The JSON response from the server.
         """
         return await self.client.arequest("DELETE", self.path + f"({id_})")
+
+
+    def get_products(
+        self,
+        filter_=None,
+        expand=None,
+        top=None,
+        inlinecount=None,
+        orderby=None,
+        select=None,
+        skip=None,
+    ):
+        """
+        Retrieves products based on the provided filters.
+
+        Args:
+            filter_ (str, optional): OData filter string.
+            inlinecount (str, optional): Option for inline count.
+            orderby (str, optional): Order by clause.
+            select (str, optional): Select specific properties.
+            skip (int, optional): Number of results to skip.
+            top (int, optional): Maximum number of results to return.
+            expand (str, optional): Expand related entities.
+
+        Returns:
+            dict: The JSON response from the server containing the products.
+        """
+        filters = {
+            "$filter": filter_,
+            "$inlinecount": inlinecount,
+            "$orderby": orderby,
+            "$select": select,
+            "$skip": skip,
+            "$top": top,
+            "$expand": expand,
+        }
+        return self.client.request(
+            "GET",
+            self.path,
+            filters={k: v for k, v in filters.items() if v is not None},
+        )
+
+    def post_product(
+        self,
+        payload,
+        filter_=None,
+        expand=None,
+        top=None,
+        inlinecount=None,
+        orderby=None,
+        select=None,
+        skip=None,
+    ):
+        filters = {
+            "$filter": filter_,
+            "$inlinecount": inlinecount,
+            "$orderby": orderby,
+            "$select": select,
+            "$skip": skip,
+            "$top": top,
+            "$expand": expand,
+        }
+        payload = json.dumps(payload)
+        return self.client.request(
+            "POST",
+            self.path,
+            filters={k: v for k, v in filters.items() if v is not None},
+            payload=payload,
+        )
+
+    def patch_product(
+        self,
+        id_: int,
+        payload: dict,
+        filter_=None,
+        expand=None,
+        top=None,
+        inlinecount=None,
+        orderby=None,
+        select=None,
+        skip=None,
+    ):
+        """
+        Updates a product by its ID with specific fields.
+
+        Args:
+            id_ (int): The ID of the product to be updated.
+            payload (dict): Fields to be updated in the product.
+            filter_ (str, optional): OData filter string.
+            inlinecount (str, optional): Option for inline count.
+            orderby (str, optional): Order by clause.
+            select (str, optional): Select specific properties.
+            skip (int, optional): Number of results to skip.
+            top (int, optional): Maximum number of results to return.
+            expand (str, optional): Expand related entities.
+
+        Returns:
+            dict: The JSON response from the server.
+        """
+        filters = {
+            "$filter": filter_,
+            "$inlinecount": inlinecount,
+            "$orderby": orderby,
+            "$select": select,
+            "$skip": skip,
+            "$top": top,
+            "$expand": expand,
+        }
+        payload = json.dumps(payload)
+        return self.client.request(
+            "PATCH",
+            self.path + f"({id_})",
+            filters={k: v for k, v in filters.items() if v is not None},
+            payload=payload,
+        )
+
+    def delete_product(self, id_: int):
+        """
+        Deletes a product by its ID.
+
+        Args:
+            id_ (int): The ID of the product to be deleted.
+
+        Returns:
+            dict: The JSON response from the server.
+        """
+        return self.client.request("DELETE", self.path + f"({id_})")

--- a/ploomes_client/collections/users.py
+++ b/ploomes_client/collections/users.py
@@ -230,7 +230,7 @@ class Users:
             "$top": top,
             "$expand": expand,
         }
-        
+        payload = json.dumps(payload)
         return self.client.request(
             "POST",
             self.path,
@@ -276,7 +276,7 @@ class Users:
             "$top": top,
             "$expand": expand,
         }
-        
+        payload = json.dumps(payload)
         return self.client.request(
             "PATCH",
             self.path + f"({id_})",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="ploomes-api-client",
-    version="0.2.146",
+    version="0.2.147",
     packages=find_packages(),
     url="https://github.com/victorfigueredo/ploomes-api-client",
     author="Victor Figueredo",


### PR DESCRIPTION
This PR addresses a critical formatting issue in the Contacts class where the payload for a POST request was being passed directly without converting it into a JSON string. This change ensures the payload is serialized correctly using json.dumps, aligning with the expected request format for the Ploomes API.
