### PR TITLE
Resolve version conflict in setup.py between stashed and upstream changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,11 @@ from setuptools import setup, find_packages
 
 setup(
     name="ploomes-api-client",
+<<<<<<< Updated upstream
     version="0.2.146",
+=======
+    version="0.2.148",
+>>>>>>> Stashed changes
     packages=find_packages(),
     url="https://github.com/victorfigueredo/ploomes-api-client",
     author="Victor Figueredo",
@@ -24,6 +28,7 @@ setup(
         "requests",
         "ratelimit",
         "pandas",
+        "httpx"
     ],
     python_requires=">=3.6",
 )

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="ploomes-api-client",
-<<<<<<< Updated upstream
-    version="0.2.146",
-=======
     version="0.2.148",
->>>>>>> Stashed changes
     packages=find_packages(),
     url="https://github.com/victorfigueredo/ploomes-api-client",
     author="Victor Figueredo",


### PR DESCRIPTION
This PR resolves a versioning conflict in setup.py, where two differing versions (0.2.146 and 0.2.148) were set due to overlapping changes between the upstream and stashed branches. 